### PR TITLE
Add target and rel attributes to mailto and tel links

### DIFF
--- a/contacto.html
+++ b/contacto.html
@@ -159,8 +159,8 @@
                             <h3 class="text-xl font-bold text-netsur-dark mb-4">Información de Contacto</h3>
                             <ul class="space-y-4 text-gray-700">
                                 <li class="flex items-start"><strong class="w-24 shrink-0">Dirección:</strong> <span>San Lorenzo 2324, Piso 4 Of C, B1650BQF, San Martín, Provincia de Buenos Aires.</span></li>
-                                <li class="flex items-start"><strong class="w-24 shrink-0">Teléfono:</strong> <a href="tel:+541147548146" class="hover:underline">(+54) 011 4754-8146</a></li>
-                                <li class="flex items-start"><strong class="w-24 shrink-0">Email:</strong> <a href="mailto:info@netsur-sa.com" class="hover:underline">info@netsur-sa.com</a></li>
+                                <li class="flex items-start"><strong class="w-24 shrink-0">Teléfono:</strong> <a href="tel:+541147548146" class="hover:underline" target="_blank" rel="noopener noreferrer">(+54) 011 4754-8146</a></li>
+                                <li class="flex items-start"><strong class="w-24 shrink-0">Email:</strong> <a href="mailto:info@netsur-sa.com" class="hover:underline" target="_blank" rel="noopener noreferrer">info@netsur-sa.com</a></li>
                                 <li class="flex items-start"><strong class="w-24 shrink-0">Horario:</strong> <span>Lunes a Viernes de 9:00 a 17:00 hs.</span></li>
                             </ul>
                         </div>
@@ -219,11 +219,11 @@
                         </li>
                         <li class="flex items-center">
                             <span class="mr-2" aria-hidden="true">📞</span>
-                             <a href="tel:+541147548146" class="hover:text-white">(+54) 011 4754-8146</a>
+                             <a href="tel:+541147548146" class="hover:text-white" target="_blank" rel="noopener noreferrer">(+54) 011 4754-8146</a>
                         </li>
                          <li class="flex items-center">
                             <span class="mr-2" aria-hidden="true">✉️</span>
-                             <a href="mailto:info@netsur-sa.com" class="hover:text-white">info@netsur-sa.com</a>
+                             <a href="mailto:info@netsur-sa.com" class="hover:text-white" target="_blank" rel="noopener noreferrer">info@netsur-sa.com</a>
                         </li>
                     </ul>
                 </div>

--- a/index.html
+++ b/index.html
@@ -242,11 +242,11 @@
                         </li>
                         <li class="flex items-center">
                             <span class="mr-2" aria-hidden="true">📞</span>
-                             <a href="tel:+541147548146" class="hover:text-white">(+54) 011 4754-8146</a>
+                             <a href="tel:+541147548146" class="hover:text-white" target="_blank" rel="noopener noreferrer">(+54) 011 4754-8146</a>
                         </li>
                          <li class="flex items-center">
                             <span class="mr-2" aria-hidden="true">✉️</span>
-                             <a href="mailto:info@netsur-sa.com" class="hover:text-white">info@netsur-sa.com</a>
+                             <a href="mailto:info@netsur-sa.com" class="hover:text-white" target="_blank" rel="noopener noreferrer">info@netsur-sa.com</a>
                         </li>
                     </ul>
                 </div>

--- a/producto-detalle.html
+++ b/producto-detalle.html
@@ -256,11 +256,11 @@
                         </li>
                         <li class="flex items-center">
                             <span class="mr-2" aria-hidden="true">📞</span>
-                             <a href="tel:+541147548146" class="hover:text-white">(+54) 011 4754-8146</a>
+                             <a href="tel:+541147548146" class="hover:text-white" target="_blank" rel="noopener noreferrer">(+54) 011 4754-8146</a>
                         </li>
                          <li class="flex items-center">
                             <span class="mr-2" aria-hidden="true">✉️</span>
-                             <a href="mailto:info@netsur-sa.com" class="hover:text-white">info@netsur-sa.com</a>
+                             <a href="mailto:info@netsur-sa.com" class="hover:text-white" target="_blank" rel="noopener noreferrer">info@netsur-sa.com</a>
                         </li>
                     </ul>
                 </div>

--- a/productos.html
+++ b/productos.html
@@ -185,11 +185,11 @@
                         </li>
                         <li class="flex items-center">
                             <span class="mr-2" aria-hidden="true">📞</span>
-                             <a href="tel:+541147548146" class="hover:text-white">(+54) 011 4754-8146</a>
+                             <a href="tel:+541147548146" class="hover:text-white" target="_blank" rel="noopener noreferrer">(+54) 011 4754-8146</a>
                         </li>
                          <li class="flex items-center">
                             <span class="mr-2" aria-hidden="true">✉️</span>
-                             <a href="mailto:info@netsur-sa.com" class="hover:text-white">info@netsur-sa.com</a>
+                             <a href="mailto:info@netsur-sa.com" class="hover:text-white" target="_blank" rel="noopener noreferrer">info@netsur-sa.com</a>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
Updated all `<a>` tags with `href` attributes starting with "tel:" or "mailto:" to include `target="_blank"` and `rel="noopener noreferrer"`.

This ensures that these links open in a new tab or window, enhancing user experience and security.